### PR TITLE
Workaround for #31: ensure the wheel package is always present

### DIFF
--- a/src/venv_manager.rs
+++ b/src/venv_manager.rs
@@ -66,6 +66,7 @@ impl VenvManager {
         }
 
         self.ensure_venv()?;
+        self.ensure_wheel()?;
         if install_options.upgrade_pip {
             self.upgrade_pip()?;
         }
@@ -157,6 +158,14 @@ impl VenvManager {
             self.create_venv()?;
         }
         Ok(())
+    }
+
+    // Workaround for broken python3-venv on Debian-like
+    // Make sure the `wheel` package is installed before
+    // doing anything else
+    fn ensure_wheel(&self) -> Result<(), Error> {
+        let args = vec!["-m", "pip", "install", "wheel"];
+        self.run_venv_cmd("python", args)
     }
 
     fn create_venv(&self) -> Result<(), Error> {


### PR DESCRIPTION
Steps to reproduce the Debian bug:

     $ python3 -m venv foo
     $ ./foo/bin/python -c 'import wheel'
     ModuleNotFoundError: No module named 'wheel'

This occurs with Python3.7rc2 and python-pip-whl 18.1-3