### PR TITLE
dm/freeze-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Next release
 
 * Add `dmenv show:bin_path` to show the path of the virtual environment binaries.
+* Fix [#31](https://github.com/TankerHQ/dmenv/issues/31): make sure the wheel
+  package gets frozen when running `dmenv lock`. Note: this also causes other packages
+  like `setuptools` and `pip` itself to get frozen. Hopefully this does not break anything.
 
 # 0.10.0
 

--- a/demo/requirements.lock
+++ b/demo/requirements.lock
@@ -4,7 +4,10 @@ attrs==18.2.0
 importlib-metadata==0.6
 more-itertools==4.3.0
 path.py==11.5.0
+pip==19.0.1
 pluggy==0.8.0
 py==1.7.0
 pytest==3.9.3
 six==1.11.0
+setuptools==40.7.1
+wheel==0.32.3

--- a/src/venv_manager.rs
+++ b/src/venv_manager.rs
@@ -399,8 +399,8 @@ impl VenvManager {
     fn install_from_lock(&self) -> Result<(), Error> {
         print_info_2(&format!("Installing dependencies from {}", LOCK_FILE_NAME));
         let as_str = &self.paths.lock.to_string_lossy();
-        let args = vec!["install", "--requirement", as_str];
-        self.run_cmd_in_venv("pip", args)
+        let args = vec!["-m", "pip", "install", "--requirement", as_str];
+        self.run_cmd_in_venv("python", args)
     }
 
     pub fn upgrade_pip(&self) -> Result<(), Error> {

--- a/src/venv_manager.rs
+++ b/src/venv_manager.rs
@@ -367,7 +367,7 @@ impl VenvManager {
         print_info_2(&format!("Generating {}", LOCK_FILE_NAME));
         let pip = self.get_path_in_venv("pip")?;
         let pip_str = pip.to_string_lossy().to_string();
-        let args = vec!["freeze", "--exclude-editable"];
+        let args = vec!["freeze", "--exclude-editable", "--all"];
         Self::print_cmd(&pip_str, &args);
         let command = std::process::Command::new(pip)
             .current_dir(&self.paths.project)


### PR DESCRIPTION
Fix #31 Turns out it was *not* debian specific after all. Sorry, Debian