### PR TITLE
Fix parsing output of `show` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16.1 (2019-07-24)
+
+* Fix regression that caused parsing output of `dmenv show` commands to stop working
+
 # 0.16.0 (2019-07-24)
 
 * Fix #94: Look for `setup.py` in the parent directories when trying to resolve the project path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ pub fn run(cmd: Command) -> Result<(), Error> {
     } else {
         look_up_for_project_path()?
     };
-    print_info_1(&format!("Using {:?} as project path", project_path));
     // Perform additional sanity checks when using `dmenv run`
     // TODO: try and handle this using StructOpt instead
     if let SubCommand::Run { ref cmd, .. } = cmd.sub_cmd {


### PR DESCRIPTION
For instance:

    source $(dmenv show:bin_path)/bin/activate

stopped working